### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/engjellushaer/c04dd773-7f95-432e-b4f7-bd389ea0a4b4/3f750269-dfb3-435d-aa16-f5e4196100c5/_apis/work/boardbadge/2d452ca5-a988-40f4-a1a3-decae97800ba)](https://dev.azure.com/engjellushaer/c04dd773-7f95-432e-b4f7-bd389ea0a4b4/_boards/board/t/3f750269-dfb3-435d-aa16-f5e4196100c5/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/engjellushaer/c04dd773-7f95-432e-b4f7-bd389ea0a4b4/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.